### PR TITLE
feat: support for vless-url config format

### DIFF
--- a/app/src/main/kotlin/com/simplexray/an/common/configFormat/ConfigFormatConverter.kt
+++ b/app/src/main/kotlin/com/simplexray/an/common/configFormat/ConfigFormatConverter.kt
@@ -1,0 +1,28 @@
+package com.simplexray.an.common.configFormat
+
+import android.content.Context
+
+interface ConfigFormatConverter {
+    fun detect(content: String): Boolean
+    fun convert(context: Context, content: String): Result<DetectedConfig>
+
+    companion object {
+        val knownImplementations = listOf(
+            SimpleXrayFormatConverter(),
+            VlessLinkConverter(),
+        )
+
+        fun convertOrNull(context: Context, content: String): Result<DetectedConfig>? {
+            for (implementation in knownImplementations) {
+                if (implementation.detect(content)) return implementation.convert(context, content)
+            }
+            return null
+        }
+
+        fun convert(context: Context, content: String): Result<DetectedConfig> {
+            return convertOrNull(context, content) ?: run {
+                return Result.success(Pair("imported_share_" + System.currentTimeMillis(), content))
+            }
+        }
+    }
+}

--- a/app/src/main/kotlin/com/simplexray/an/common/configFormat/DetectedConfig.kt
+++ b/app/src/main/kotlin/com/simplexray/an/common/configFormat/DetectedConfig.kt
@@ -1,0 +1,3 @@
+package com.simplexray.an.common.configFormat
+
+typealias DetectedConfig = Pair<String, String>

--- a/app/src/main/kotlin/com/simplexray/an/common/configFormat/SimpleXrayFormatConverter.kt
+++ b/app/src/main/kotlin/com/simplexray/an/common/configFormat/SimpleXrayFormatConverter.kt
@@ -1,0 +1,47 @@
+package com.simplexray.an.common.configFormat
+
+import android.content.Context
+import android.util.Log
+import com.simplexray.an.common.FilenameValidator
+import com.simplexray.an.data.source.FileManager.Companion.TAG
+import java.io.ByteArrayOutputStream
+import java.net.URLDecoder
+import java.util.Base64
+import java.util.zip.Inflater
+
+class SimpleXrayFormatConverter: ConfigFormatConverter {
+    override fun detect(content: String): Boolean {
+        return content.startsWith("simplexray://config/")
+    }
+
+    override fun convert(context: Context, content: String): Result<DetectedConfig> {
+        val parts = content.substring("simplexray://config/".length).split("/")
+        if (parts.size != 2) {
+            Log.e(TAG, "Invalid simplexray URI format")
+            return Result.failure(RuntimeException("Invalid simplexray URI format"))
+        }
+
+        val decodedName = URLDecoder.decode(parts[0], "UTF-8")
+
+        val filenameError = FilenameValidator.validateFilename(context, decodedName)
+        if (filenameError != null) {
+            Log.e(TAG, "Invalid filename in simplexray URI: $filenameError")
+            return Result.failure(RuntimeException("Invalid filename in simplexray URI: $filenameError"))
+        }
+
+        val decodedContent = Base64.getUrlDecoder().decode(parts[1])
+
+        val inflater = Inflater()
+        inflater.setInput(decodedContent)
+        val outputStream = ByteArrayOutputStream()
+        val buffer = ByteArray(1024)
+        while (!inflater.finished()) {
+            val count = inflater.inflate(buffer)
+            outputStream.write(buffer, 0, count)
+        }
+        inflater.end()
+        val decompressed = outputStream.toByteArray().toString(Charsets.UTF_8)
+
+        return Result.success(Pair(decodedName, decompressed))
+    }
+}

--- a/app/src/main/kotlin/com/simplexray/an/common/configFormat/VlessLinkConverter.kt
+++ b/app/src/main/kotlin/com/simplexray/an/common/configFormat/VlessLinkConverter.kt
@@ -1,0 +1,91 @@
+package com.simplexray.an.common.configFormat
+
+import android.content.Context
+import android.net.Uri
+import androidx.core.net.toUri
+import com.simplexray.an.prefs.Preferences
+import org.json.JSONArray
+import org.json.JSONObject
+import java.net.MalformedURLException
+import java.net.URL
+
+class VlessLinkConverter: ConfigFormatConverter {
+    override fun detect(content: String): Boolean {
+        return content.startsWith("vless://")
+    }
+
+    override fun convert(context: Context, content: String): Result<DetectedConfig> {
+        return try {
+            val url = content.toUri()
+            assert(url.scheme == "vless")
+
+            val name = url.fragment ?: ("imported_vless_" + System.currentTimeMillis())
+            val address = url.host ?: return Result.failure(MalformedURLException("Missing host"))
+            val port = url.port.takeIf { it != -1 } ?: 443
+            val id = url.userInfo ?: return Result.failure(MalformedURLException("Missing user info"))
+
+            val type = url.getQueryParameter("type")?.let { if (it == "h2") "http" else it } ?: "tcp"
+            val security = url.getQueryParameter("security") ?: "reality"
+            val sni = url.getQueryParameter("sni") ?: url.getQueryParameter("peer")
+            val fingerprint = url.getQueryParameter("fp") ?: "chrome"
+            val flow = url.getQueryParameter("flow") ?: "xtls-rprx-vision"
+
+            val realityPbk = url.getQueryParameter("pbk") ?: ""
+            val realityShortId = url.getQueryParameter("sid") ?: ""
+            val spiderX = url.getQueryParameter("spx") ?: "/"
+
+            val socksPort = Preferences(context).socksPort
+
+            // Build config JSON
+            val config = JSONObject(
+                mapOf(
+                    "log" to mapOf("loglevel" to "warning"),
+                    "inbounds" to listOf(
+                        mapOf(
+                            "port" to socksPort,
+                            "listen" to "127.0.0.1",
+                            "protocol" to "socks",
+                            "settings" to mapOf("udp" to true)
+                        )
+                    ),
+                    "outbounds" to listOf(
+                        mapOf(
+                            "protocol" to "vless",
+                            "settings" to mapOf(
+                                "vnext" to listOf(
+                                    mapOf(
+                                        "address" to address,
+                                        "port" to port,
+                                        "users" to listOf(
+                                            mapOf(
+                                                "id" to id,
+                                                "encryption" to "none",
+                                                "flow" to flow
+                                            )
+                                        )
+                                    )
+                                )
+                            ),
+                            "streamSettings" to mapOf(
+                                "network" to type,
+                                "security" to security,
+                                "realitySettings" to mapOf(
+                                    "show" to false,
+                                    "fingerprint" to fingerprint,
+                                    "serverName" to (sni ?: address),
+                                    "publicKey" to realityPbk,
+                                    "shortId" to realityShortId,
+                                    "spiderX" to spiderX
+                                )
+                            )
+                        )
+                    )
+                )
+            )
+
+            Result.success(DetectedConfig(name, config.toString(2)))
+        } catch (e: Throwable) {
+            Result.failure(e)
+        }
+    }
+}


### PR DESCRIPTION
Добавлена возможность создавать конфиги из ссылок вида vless://, обработка форматов конфига вынесена в отдельную систему, реализация для simplexray:// полностью сохранена.