### PR TITLE
keep background service not be killed when disableVpn = true

### DIFF
--- a/app/src/main/kotlin/com/simplexray/an/service/TProxyService.kt
+++ b/app/src/main/kotlin/com/simplexray/an/service/TProxyService.kt
@@ -128,6 +128,11 @@ class TProxyService : VpnService() {
                     val successIntent = Intent(ACTION_START)
                     successIntent.setPackage(application.packageName)
                     sendBroadcast(successIntent)
+
+                    @Suppress("SameParameterValue") val channelName = "nosocks"
+                    initNotificationChannel(channelName)
+                    createNotification(channelName)
+
                 } else {
                     startXray()
                 }


### PR DESCRIPTION
app killed by system (android 11) when disableVpn=true . i added a notification channel when started with disableVpn=true mode.

app 在disableVpn=true模式下仍然会被杀后台(移动云手机），我在disableVpn=true下也添加了notification channel，为了保证后台不被杀掉